### PR TITLE
rpmdb relocation: Use macro instead of a symlink

### DIFF
--- a/src/imgbased/plugins/build.py
+++ b/src/imgbased/plugins/build.py
@@ -109,8 +109,9 @@ def relocate_rpm_and_yum_dbs():
     log.info("Relocating rpmdb")
     # Move out of /var
     shutil.move("/var/lib/rpm", "/usr/share/rpm")
-    # Make the /var entry a symlink to the moved db
-    os.symlink("../../usr/share/rpm", "/var/lib/rpm")
+    # Make 'rpm' look there
+    with open('/etc/rpm/macros', 'w') as f:
+        f.write('%_dbpath /usr/share/rpm\n')
 
     for d in ('yum', 'dnf'):
         orig_path = "/var/lib/{}".format(d)


### PR DESCRIPTION
## Changes introduced with this PR

creates `/etc/rpm/macros` overriding `%_dbpath` pointing to `/usr/share/rpm` instead of using symlinks.

Related-To: https://bugzilla.redhat.com/show_bug.cgi?id=2032043

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y