### PR TITLE
Do not persist ovirt-node-ng-image-update-placeholder

### DIFF
--- a/src/plugin-yum/imgbased-persist.conf
+++ b/src/plugin-yum/imgbased-persist.conf
@@ -1,4 +1,4 @@
 [main]
 enabled=1
-excluded_pkgs=redhat-virtualization-host-image-update,ovirt-node-ng-image-update,rhvm-appliance,ovirt-engine-appliance
+excluded_pkgs=redhat-virtualization-host-image-update,ovirt-node-ng-image-update,ovirt-node-ng-image-update-placeholder,rhvm-appliance,ovirt-engine-appliance
 bootsetup_pkgs=kernel


### PR DESCRIPTION
We do not need to persist ovirt-node-ng-image-update-placeholder.noarch,
as this can cause some troubles when upgrading.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2100002
Signed-off-by: Jean-Louis Dupond <jean-louis@dupond.be>

## Changes introduced with this PR
We should not persist the ovirt-node-ng-image-update-placeholder, as this causes imgbase to install it again on the next upgrade, causing downgrade/mixed versions.
This is one possible fix for the issue in the bugurl above.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[n]